### PR TITLE
Update default configuration option `shouldClearDestinationDuringRelease`

### DIFF
--- a/default.config.json
+++ b/default.config.json
@@ -30,7 +30,7 @@
 	"useNormalizeCss": false,
 	"usePostCSS": true,
 	"enableCssStructureMinimization": false,
-	"shouldClearDestinationDuringRelease": true,
+	"shouldClearDestinationDuringRelease": false,
 
 	"watchInterval": 1000,
 

--- a/doc/configs.md
+++ b/doc/configs.md
@@ -33,7 +33,7 @@
 	"useNormalizeCss": false, // see normalize.css
 	"usePostCSS": true, // autoprefixer, opacity, filters
 	"enableCssStructureMinimization": false, // see gulp-csso
-	"shouldClearDestinationDuringRelease": true,
+	"shouldClearDestinationDuringRelease": false,
 
     "watchInterval": 1000,
 
@@ -58,6 +58,9 @@ config = {
 };
 csstime.loadGulpTasks(gulp, config);
 ```
+
+If you want to clear destination directory during release process to remove deprecated files,
+you can set configuration option `shouldClearDestinationDuringRelease` to `true`.
 
 ## Imagemin default config
 To override use "imageminConfig" option.

--- a/doc/migrations.md
+++ b/doc/migrations.md
@@ -17,7 +17,7 @@ New options:
 * "componentsRootDirs": ["src/components"],
 * "componentAssetsDir": "assets",
 * "componentJSON": "component.json",
-* "shouldClearDestinationDuringRelease": true.
+* "shouldClearDestinationDuringRelease": false.
 
 If you use [Catberry.js](http://catberry.org) v4 and csstime-gulp-tasks v3,
 you can simple migrate to csstime-gulp-tasks v4 doing so:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "csstime-gulp-tasks",
-	"version": "4.0.2",
+	"version": "4.1.0",
 	"description": "Prepared Gulp tasks to build and optimize assets of your project (LESS, CSS, SVG, images, sprites and more)",
 	"author": "Julia Rechkunova",
 	"main": "index.js",


### PR DESCRIPTION
Option `shouldClearDestinationDuringRelease` in configuration is `false` now. It's more safe to keep files  after previous release.
