### PR TITLE
Handle excludes paths in csscomb task

### DIFF
--- a/configs/csscomb.json
+++ b/configs/csscomb.json
@@ -1,4 +1,5 @@
 {
 	"sources": "src/components",
+	"excludes": [],
 	"configPath": "configs/.csscomb.json"
 }

--- a/doc/configs.md
+++ b/doc/configs.md
@@ -113,6 +113,7 @@ To override use "csscombConfig" option.
 ```json
 {
 	"sources": "src/components",
+	"excludes": [],
 	"configPath": "configs/.csscomb.json"
 }
 ```

--- a/gulp-tasks/csstime-exec-csscomb.js
+++ b/gulp-tasks/csstime-exec-csscomb.js
@@ -11,12 +11,16 @@ module.exports = function (gulp, plugins, config) {
 					defaultCsscombConfig.configPath) ?
 					path.join(config.packagePath,
 						defaultCsscombConfig.configPath) :
-					config.csscombConfig.configPath;
-
-			return gulp.src([
+					config.csscombConfig.configPath,
+				excludes = config.csscombConfig.excludes.map(function(path) {
+					return '!' + path;
+				}),
+				sources = [
 					path.join(config.csscombConfig.sources, '**', '*.less'),
 					path.join(config.csscombConfig.sources, '**', '*.css')
-				])
+				];
+
+			return gulp.src(sources.concat(excludes))
 				.pipe(plugins.csscomb(configPath))
 				.pipe(gulp.dest(config.csscombConfig.sources));
 		}

--- a/gulp-tasks/csstime-exec-csscomb.js
+++ b/gulp-tasks/csstime-exec-csscomb.js
@@ -12,7 +12,7 @@ module.exports = function (gulp, plugins, config) {
 					path.join(config.packagePath,
 						defaultCsscombConfig.configPath) :
 					config.csscombConfig.configPath,
-				excludes = config.csscombConfig.excludes || null,
+				excludes = config.csscombConfig.excludes || [],
 				sources = [
 					path.join(config.csscombConfig.sources, '**', '*.less'),
 					path.join(config.csscombConfig.sources, '**', '*.css')

--- a/gulp-tasks/csstime-exec-csscomb.js
+++ b/gulp-tasks/csstime-exec-csscomb.js
@@ -12,15 +12,20 @@ module.exports = function (gulp, plugins, config) {
 					path.join(config.packagePath,
 						defaultCsscombConfig.configPath) :
 					config.csscombConfig.configPath,
-				excludes = config.csscombConfig.excludes.map(function(path) {
-					return '!' + path;
-				}),
+				excludes = config.csscombConfig.excludes || null,
 				sources = [
 					path.join(config.csscombConfig.sources, '**', '*.less'),
 					path.join(config.csscombConfig.sources, '**', '*.css')
 				];
 
-			return gulp.src(sources.concat(excludes))
+			if (Array.isArray(excludes) && excludes.length > 0) {
+				excludes = excludes.map(function(path) {
+					return '!' + path;
+				});
+				sources = sources.concat(excludes);
+			}
+
+			return gulp.src(sources)
 				.pipe(plugins.csscomb(configPath))
 				.pipe(gulp.dest(config.csscombConfig.sources));
 		}


### PR DESCRIPTION
Changing exclude parameter in config/.csscomb.json has no effect on csstime-exec-csscomb task.
Now we can set excludes in config/csscomb.json like this

``` json
{
    "sources": "src/components",
    "excludes": [
        "src/components/component_1/style.less",
        "src/components/component_2/style.less"
    ],
    "configPath": "configs/.csscomb.json"
}
```
