### PR TITLE
Handle excludes paths in csscomb task

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ List of used packages:
 * gulp-imagemin,
 * gulp-less,
 * gulp-postcss,
-* gulp-svg2png,
 * gulp-svgstore,
 * gulp-uglify,
 * gulp.spritesmith,

--- a/configs/csscomb.json
+++ b/configs/csscomb.json
@@ -1,4 +1,5 @@
 {
 	"sources": "src/components",
+	"excludes": [],
 	"configPath": "configs/.csscomb.json"
 }

--- a/default.config.json
+++ b/default.config.json
@@ -32,7 +32,6 @@
 	"useImageOptimization": true,
 
 	"useSvgOptimization": true,
-	"useSvgRasterization": true,
 	"useSvgSymbols": false,
 	"svgSymbolsPrefix": "icon-",
 

--- a/doc/configs.md
+++ b/doc/configs.md
@@ -35,7 +35,6 @@
 	"useImageOptimization": true, // see gulp-imagemin
 
 	"useSvgOptimization": true, // see gulp-imagemin (svgo)
-	"useSvgRasterization": true, // see gulp-svg2png
 	"useSvgSymbols": false,
    	"svgSymbolsPrefix": "icon-",
 

--- a/doc/configs.md
+++ b/doc/configs.md
@@ -113,6 +113,7 @@ To override use "csscombConfig" option.
 ```json
 {
 	"sources": "src/components",
+	"excludes": [],
 	"configPath": "configs/.csscomb.json"
 }
 ```

--- a/doc/tasks.md
+++ b/doc/tasks.md
@@ -27,7 +27,7 @@ Low level tasks:
 | `csstime-collect-sprites`	| `/src/components/**/assets/sprites` => `/public`<br>Build and optimize sprites									| `__csstime-tmp/sprites.less`,<br>`build/assets/sprites.png`			|
 | `csstime-collect-images`	| `/src/components/**/assets/images` => `/build/assets/*/images`<br>Copy and optimize images				        | optimized images														|
 | `csstime-collect-fonts`	| `/src/components/**/assets/fonts` => `/build/assets/*/fonts`<br>Copy fonts								        | same fonts															|
-| `csstime-collect-svg`	    | `/src/components/**/assets/svg` => `/build/assets/*/svg`<br>Copy svg, optimise and rasterize them		            | optimised svg, png fallbacks											|
+| `csstime-collect-svg`	    | `/src/components/**/assets/svg` => `/build/assets/*/svg`<br>Copy svg and optimise them        		            | optimised svg											                |
 | `csstime-combine-svg`	    | `/src/components/**/assets/symbols` => `/build/assets/symbols.svg`<br>Combine svg             		            | optimised and combined svg											|
 | `csstime-collect-other`	| `/src/components/**/assets/other` => `/build/assets/*/other`<br>Copy files								        | same files															|
 | `csstime-concat-less`		| `/src/components/**/assets/less` => `/build/__csstime-tmp`<br>Create main less file with import references	    | `styles.less`															|

--- a/gulp-tasks/csstime-collect-svg.js
+++ b/gulp-tasks/csstime-collect-svg.js
@@ -30,20 +30,7 @@ module.exports = function (gulp, plugins, config) {
 					plugins.lib.pathHelper
 						.renamePathToComponentName(config, filePath);
 				}))
-				.pipe(gulp.dest(destination))
-				.pipe(plugins.if(
-					config.useSvgRasterization,
-					plugins.svg2png()
-				))
-				.pipe(plugins.if(
-					config.isRelease &&
-						config.useSvgRasterization && config.useImageOptimization,
-					plugins.imagemin(config.imageminConfig)
-				))
-				.pipe(plugins.if(
-					config.useSvgRasterization,
-					gulp.dest(destination)
-				));
+				.pipe(gulp.dest(destination));
 		}
 	};
 };

--- a/gulp-tasks/csstime-exec-csscomb.js
+++ b/gulp-tasks/csstime-exec-csscomb.js
@@ -11,12 +11,16 @@ module.exports = function (gulp, plugins, config) {
 					defaultCsscombConfig.configPath) ?
 					path.join(config.packagePath,
 						defaultCsscombConfig.configPath) :
-					config.csscombConfig.configPath;
-
-			return gulp.src([
+					config.csscombConfig.configPath,
+				excludes = config.csscombConfig.excludes.map(function(path) {
+					return '!' + path;
+				}),
+				sources = [
 					path.join(config.csscombConfig.sources, '**', '*.less'),
 					path.join(config.csscombConfig.sources, '**', '*.css')
-				])
+				];
+
+			return gulp.src(sources.concat(excludes))
 				.pipe(plugins.csscomb(configPath))
 				.pipe(gulp.dest(config.csscombConfig.sources));
 		}

--- a/gulp-tasks/csstime-exec-csscomb.js
+++ b/gulp-tasks/csstime-exec-csscomb.js
@@ -12,7 +12,7 @@ module.exports = function (gulp, plugins, config) {
 					path.join(config.packagePath,
 						defaultCsscombConfig.configPath) :
 					config.csscombConfig.configPath,
-				excludes = config.csscombConfig.excludes || null,
+				excludes = config.csscombConfig.excludes || [],
 				sources = [
 					path.join(config.csscombConfig.sources, '**', '*.less'),
 					path.join(config.csscombConfig.sources, '**', '*.css')

--- a/gulp-tasks/csstime-exec-csscomb.js
+++ b/gulp-tasks/csstime-exec-csscomb.js
@@ -12,15 +12,20 @@ module.exports = function (gulp, plugins, config) {
 					path.join(config.packagePath,
 						defaultCsscombConfig.configPath) :
 					config.csscombConfig.configPath,
-				excludes = config.csscombConfig.excludes.map(function(path) {
-					return '!' + path;
-				}),
+				excludes = config.csscombConfig.excludes || null,
 				sources = [
 					path.join(config.csscombConfig.sources, '**', '*.less'),
 					path.join(config.csscombConfig.sources, '**', '*.css')
 				];
 
-			return gulp.src(sources.concat(excludes))
+			if (Array.isArray(excludes) && excludes.length > 0) {
+				excludes = excludes.map(function(path) {
+					return '!' + path;
+				});
+				sources = sources.concat(excludes);
+			}
+
+			return gulp.src(sources)
 				.pipe(plugins.csscomb(configPath))
 				.pipe(gulp.dest(config.csscombConfig.sources));
 		}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "csstime-gulp-tasks",
-	"version": "4.3.2",
+	"version": "5.0.0",
 	"description": "Prepared Gulp tasks to build and optimize assets of your project (LESS, CSS, SVG, images, sprites and more)",
 	"author": "Julia Rechkunova",
 	"main": "index.js",
@@ -37,7 +37,6 @@
 		"gulp-less": "^3.0.0",
 		"gulp-postcss": "^5.1.3",
 		"gulp-rename": "^1.2.2",
-		"gulp-svg2png": "^0.3.0",
 		"gulp-svgstore": "^5.0.4",
 		"gulp-uglify": "^1.1.0",
 		"gulp-util": "^3.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "csstime-gulp-tasks",
-	"version": "5.0.0",
+	"version": "5.0.1",
 	"description": "Prepared Gulp tasks to build and optimize assets of your project (LESS, CSS, SVG, images, sprites and more)",
 	"author": "Julia Rechkunova",
 	"main": "index.js",

--- a/test/mocks/app/src/components/elements/logo/assets/less/logo.less
+++ b/test/mocks/app/src/components/elements/logo/assets/less/logo.less
@@ -7,8 +7,3 @@
 	background-repeat: no-repeat;
 	background-size: @logo-size @logo-size;
 }
-
-/* png fallback */
-.no-svg .logo {
-	background: url('{@CDN}logo/svg/color.png');
-}


### PR DESCRIPTION
Changing exclude parameter in config/.csscomb.json has no effect on csstime-exec-csscomb task.
Now we can set excludes in config/csscomb.json like this

``` json
{
    "sources": "src/components",
    "excludes": [
        "src/components/component_1/style.less",
        "src/components/component_2/style.less"
    ],
    "configPath": "configs/.csscomb.json"
}
```
