### PR TITLE
Introduce custom variables to use them for preprocessors

### DIFF
--- a/default.config.json
+++ b/default.config.json
@@ -56,5 +56,7 @@
 
 	"banner": "/**\n * csstime\n * <%now%>\n */\n",
 
-	"cdnPath": "/components/"
+	"cdnPath": "/components/",
+
+	"variables": {}
 }

--- a/doc/configs.md
+++ b/doc/configs.md
@@ -61,6 +61,8 @@
 
 	"cdnPath": "/components/", // used in urls for sprites in css
 
+	"variables": {}, // pass custom variables to use them in preprocessors
+
 	"imageminConfig": {}, // see ./configs files or read further
 	"postcssConfig": {},
 	"spritesmithConfig": {},

--- a/index.js
+++ b/index.js
@@ -95,6 +95,7 @@ CsstimeGulpTask.prototype.getConfig = function (options) {
 	currentConfig.packagePath = __dirname;
 	currentConfig.preprocessorExt =
 		currentConfig.preprocessorsConfig[currentConfig.preprocessor].ext;
+	currentConfig.variables = currentConfig.variables || {};
 	return currentConfig;
 };
 

--- a/tasks/concat-named-preprocessor.js
+++ b/tasks/concat-named-preprocessor.js
@@ -5,13 +5,9 @@ var path = require('path'),
 	fs = require('fs');
 
 var IMPORT_FORMAT = '/*\n * Styles of component "%s"\n */\n@import "%s";',
-	BASE_VARIABLES = {
-		less: '@CDN: "%s";',
-		sass: '$CDN: "%s";'
-	},
-	SPRITES_VARIABLES = {
-		less: '@SPRITES_IMAGE: "%s";',
-		sass: '$SPRITES_IMAGE: "%s";'
+	VARIABLE_FORMAT = {
+		less: '@%s: "%s";',
+		sass: '$%s: "%s";'
 	};
 
 module.exports = {
@@ -29,17 +25,30 @@ module.exports = {
 				.getAssetsDirectories(config),
 			imports = [];
 
-		// variables
-		imports.push(util.format(BASE_VARIABLES[config.preprocessor],
-			config.cdnPath));
+		// cdn variable
+		imports.push(util.format(
+			VARIABLE_FORMAT[config.preprocessor],
+			'CDN',
+			config.cdnPath
+		));
 
-		// sprites
+		// sprites variable
 		if (config.useImageSprites) {
 			imports.push(util.format(
-				SPRITES_VARIABLES[config.preprocessor],
+				VARIABLE_FORMAT[config.preprocessor],
+				'SPRITES_IMAGE',
 				config.spritesFileName + '.png'
 			));
 		}
+		
+		// custom variables
+		Object.keys(config.variables).forEach(function (variableKey) {
+			imports.push(util.format(
+				VARIABLE_FORMAT[config.preprocessor],
+				variableKey,
+				config.variables[variableKey]
+			));
+		});
 
 		// less/sass
 		componentsDirectories.forEach(function (component) {


### PR DESCRIPTION
New option in config:

``` javascript
{
  variables: {
    MY_VARIABLE: 'fancy'
  }
}
```

It will generate variables for preprocessors like:

```
$MY_VARIABLE: "fancy";
```
